### PR TITLE
Fix GetAtt syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The first component to be deployed is the centralised `API Gateway`. This is use
 ``` bash
 cd apigateway
 npm ci
-npm run sls -- deploy --stage {stage-name}
+npm run sls -- deploy [--stage {stage-name}]
 ```
 
 For more information about the API Gateway setup, see the individual [readme](/apigateway) file.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ For more information about the `Streams ES` setup, see the individual [readme](/
 A `Serverless Artillery` setup has been configured to allow an initial data load to be carried out.
 
 ```bash
-cd loadtesting
+cd loadtest
 npm ci
 ```
 

--- a/streams-es/serverless.yml
+++ b/streams-es/serverless.yml
@@ -15,7 +15,7 @@ provider:
     restApiId: !ImportValue QldbApiGateway-restApiId
     restApiRootResourceId: !ImportValue QldbApiGateway-rootResourceId
   environment:
-    AWS_NODEJS_CONNECTION_REUSE_ENABLED	: "1"
+    AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1"
 
 plugins:
   - serverless-iam-roles-per-function

--- a/streams-es/serverless.yml
+++ b/streams-es/serverless.yml
@@ -45,7 +45,7 @@ functions:
           arn: !GetAtt licenceQldbStreamsES.Arn
     vpc:
       securityGroupIds:
-        - "Fn::GetAtt": ElasticSecurityGroup.GroupId
+        - !GetAtt ElasticSecurityGroup.GroupId
       subnetIds:
         - Ref: ElasticSubnetA
     iamRoleStatementsName: qldb-streams-es-lambda-role-${self:provider.stage}
@@ -87,7 +87,7 @@ functions:
           method: get
     vpc:
       securityGroupIds:
-        - "Fn::GetAtt": ElasticSecurityGroup.GroupId
+        - !GetAtt ElasticSecurityGroup.GroupId
       subnetIds:
         - Ref: ElasticSubnetA
     iamRoleStatementsName: es-search-role-${self:provider.stage}


### PR DESCRIPTION
Deploying the current version results in this error. 

`The CloudFormation template is invalid: Template error: every Fn::GetAtt object requires two non-empty parameters, the resource name and the resource attribute`